### PR TITLE
Handle empty environment overrides in vendor worker

### DIFF
--- a/trademl/workers/vendor_worker.py
+++ b/trademl/workers/vendor_worker.py
@@ -35,6 +35,25 @@ def _normalize_vendor(v: str) -> str:
     return m
 
 
+def _env_int(name: str, default: int = 0) -> int:
+    """Read an integer environment variable safely."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        raw = raw.strip()
+    except AttributeError:
+        # Non-string values (rare) are ignored and defaulted
+        return default
+    if raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
 def _tasks_for_vendor_all(edge, vendor: str) -> List[str]:
     # Mirror mapping logic from VendorSupervisor
     mapping = {
@@ -98,8 +117,8 @@ def main():
 
     parser = argparse.ArgumentParser(description="Per-vendor worker")
     parser.add_argument("--vendor", default=os.getenv("VENDOR"), required=False)
-    parser.add_argument("--concurrency", type=int, default=int(os.getenv("CONCURRENCY", "0")))
-    parser.add_argument("--rpm", type=int, default=int(os.getenv("RPM_LIMIT", "0")))
+    parser.add_argument("--concurrency", type=int, default=_env_int("CONCURRENCY", 0))
+    parser.add_argument("--rpm", type=int, default=_env_int("RPM_LIMIT", 0))
     parser.add_argument("--budget", type=int, default=os.getenv("BUDGET") or 0)
     parser.add_argument("--config", default=os.getenv("EDGE_CONFIG", "configs/edge.yml"))
     parser.add_argument("--tasks", default=os.getenv("TASKS", ""))


### PR DESCRIPTION
## Summary
- add a helper to safely parse integer environment overrides for the vendor worker CLI
- default concurrency and RPM limits to zero when the corresponding environment variables are blank or invalid

## Testing
- python -m compileall trademl/workers/vendor_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68f0a7871d2c8326bf51e7844bef8cde